### PR TITLE
Add automated release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: Bump version and push tag
+        id: version
+        uses: anothrNick/github-tag-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/cluster-rollback:${{ steps.version.outputs.new_tag }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.version.outputs.new_tag }}
+          name: Release ${{ steps.version.outputs.new_tag }}
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+

--- a/README.md
+++ b/README.md
@@ -94,3 +94,13 @@ spec:
 Expose the service with an Ingress or a LoadBalancer according to your
 environment. Once deployed, access the UI and use the timeline to select the
 desired snapshot and roll back with a single click.
+
+## Continuous delivery
+
+Merging changes to the `master` or `main` branch triggers a GitHub Actions workflow that:
+
+1. Bumps the project version and creates a new Git tag.
+2. Builds and pushes the Docker image to Docker Hub.
+3. Generates release notes from the commit history and publishes a GitHub release.
+
+Docker credentials must be provided via `DOCKER_USERNAME` and `DOCKER_TOKEN` repository secrets. The workflow uses the built-in `GITHUB_TOKEN` to publish releases.


### PR DESCRIPTION
## Summary
- create GitHub Actions workflow to tag new releases
- build and push Docker image to Docker Hub automatically
- document the new workflow in README
- use Docker token and explicit GitHub token for release

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile cluster_rollback/*.py`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_687d244133dc832aac4d5b397ff773ee