### PR TITLE
Use latest image for deployment examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ MVP but can be added later.
 
 ## Deploying to Kubernetes
 
-Build the Docker image:
+Use the pre-built Docker image:
 
 ```bash
-docker build -t myrepo/cluster-rollback:latest .
+docker pull harchuk/cluster-rollback:latest
 ```
 
 Apply the following manifest to run the tool in your cluster. A copy is
@@ -74,7 +74,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: myrepo/cluster-rollback:latest
+          image: harchuk/cluster-rollback:latest
           command: ["python", "-m", "cluster_rollback.web.app"]
           ports:
             - containerPort: 8000

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: myrepo/cluster-rollback:latest
+        image: harchuk/cluster-rollback:latest
         command: ["python", "-m", "cluster_rollback.web.app"]
         ports:
         - containerPort: 8000


### PR DESCRIPTION
## Summary
- pull `harchuk/cluster-rollback:latest` in the README
- run the same image in the provided Kubernetes manifest

## Testing
- `python -m compileall -q cluster_rollback`


------
https://chatgpt.com/codex/tasks/task_b_687d284f1d48832a9a8fcae3e92967ee