### PR TITLE
Publish Docker image to GHCR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,13 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_TOKEN }}
 
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Bump version and push tag
         id: version
         uses: anothrNick/github-tag-action@v1
@@ -39,7 +46,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/cluster-rollback:${{ steps.version.outputs.new_tag }}
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/cluster-rollback:${{ steps.version.outputs.new_tag }}
+            ghcr.io/${{ github.repository_owner }}/cluster-rollback:${{ steps.version.outputs.new_tag }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ MVP but can be added later.
 
 ## Deploying to Kubernetes
 
-Use the pre-built Docker image:
+Use the pre-built Docker image from the GitHub Container Registry:
 
 ```bash
-docker pull harchuk/cluster-rollback:latest
+docker pull ghcr.io/harchuk/cluster-rollback:latest
 ```
 
 Apply the following manifest to run the tool in your cluster. A copy is
@@ -74,7 +74,7 @@ spec:
     spec:
       containers:
         - name: web
-          image: harchuk/cluster-rollback:latest
+          image: ghcr.io/harchuk/cluster-rollback:latest
           command: ["python", "-m", "cluster_rollback.web.app"]
           ports:
             - containerPort: 8000
@@ -100,7 +100,7 @@ desired snapshot and roll back with a single click.
 Merging changes to the `master` or `main` branch triggers a GitHub Actions workflow that:
 
 1. Bumps the project version and creates a new Git tag.
-2. Builds and pushes the Docker image to Docker Hub.
+2. Builds the Docker image and pushes it to Docker Hub and the GitHub Container Registry.
 3. Generates release notes from the commit history and publishes a GitHub release.
 
-Docker credentials must be provided via `DOCKER_USERNAME` and `DOCKER_TOKEN` repository secrets. The workflow uses the built-in `GITHUB_TOKEN` to publish releases.
+Docker credentials must be provided via `DOCKER_USERNAME` and `DOCKER_TOKEN` repository secrets for Docker Hub. The built-in `GITHUB_TOKEN` is used for publishing to `ghcr.io` and creating releases.

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
       - name: web
-        image: harchuk/cluster-rollback:latest
+        image: ghcr.io/harchuk/cluster-rollback:latest
         command: ["python", "-m", "cluster_rollback.web.app"]
         ports:
         - containerPort: 8000


### PR DESCRIPTION
## Summary
- push Docker images to ghcr.io in the release workflow
- update k8s manifests and README to use `ghcr.io/harchuk/cluster-rollback:latest`
- document pushing to Docker Hub and GHCR

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m compileall -q cluster_rollback`


------
https://chatgpt.com/codex/tasks/task_b_687d2c65e5f4832ab5d3a316fc99b50c