### PR TITLE
Add latest tag push in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/cluster-rollback:${{ steps.version.outputs.new_tag }}
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/cluster-rollback:${{ steps.version.outputs.new_tag }}
+            ${{ secrets.DOCKER_USERNAME }}/cluster-rollback:latest
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ desired snapshot and roll back with a single click.
 Merging changes to the `master` or `main` branch triggers a GitHub Actions workflow that:
 
 1. Bumps the project version and creates a new Git tag.
-2. Builds and pushes the Docker image to Docker Hub.
+2. Builds and pushes the Docker image to Docker Hub with both the versioned and `latest` tags.
 3. Generates release notes from the commit history and publishes a GitHub release.
 
 Docker credentials must be provided via `DOCKER_USERNAME` and `DOCKER_TOKEN` repository secrets. The workflow uses the built-in `GITHUB_TOKEN` to publish releases.


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow to push Docker image with version and `latest`
- document that both tags are pushed during continuous delivery

## Testing
- `python -m compileall -q cluster_rollback`

------
https://chatgpt.com/codex/tasks/task_b_687d2b717bbc832a877d5031b2809c94