### PR TITLE
Enable arm64 Docker image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -46,6 +49,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ secrets.DOCKER_USERNAME }}/cluster-rollback:${{ steps.version.outputs.new_tag }}
             ${{ secrets.DOCKER_USERNAME }}/cluster-rollback:latest

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Merging changes to the `master` or `main` branch triggers a GitHub Actions workf
 
 1. Bumps the project version and creates a new Git tag.
 
-2. Builds the Docker image and pushes it to Docker Hub and the GitHub Container Registry with both the versioned and `latest` tags..
+2. Builds multi-platform Docker images (linux/amd64 and linux/arm64) and pushes them to Docker Hub and the GitHub Container Registry with both the versioned and `latest` tags.
 
 3. Generates release notes from the commit history and publishes a GitHub release.
 


### PR DESCRIPTION
## Summary
- support multi-platform images in CI using Buildx and QEMU
- document arm64 build support

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_687d30c8a69c832aa857293de035cd48