### PR TITLE
Replace kubectl CLI with Kubernetes client

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It includes both a CLI utility and a web interface with a timeline of commits.
 ## Requirements
 
 * Python 3.8+
-* `kubectl` configured for your cluster
+* Access to your cluster via a kubeconfig file (no `kubectl` required)
 * Access to a local or remote Git repository
 
 Install dependencies:

--- a/cluster_rollback/web/app.py
+++ b/cluster_rollback/web/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, render_template_string, redirect, url_for
 from git import Repo
-import subprocess
+from kubernetes import client, config, utils
 import os
 
 app = Flask(__name__)
@@ -51,7 +51,8 @@ def rollback(commit):
     timestamp = obj.message.strip().split()[1]
     repo.git.checkout(commit, '--', SNAPSHOT_DIR)
     snapshot_path = os.path.join(SNAPSHOT_DIR, timestamp, 'resources.yaml')
-    subprocess.run(['kubectl', 'apply', '-f', snapshot_path], check=True)
+    config.load_kube_config()
+    utils.create_from_yaml(client.ApiClient(), snapshot_path)
     return redirect(url_for('index'))
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- drop dependency on `kubectl`
- gather resources using the Kubernetes client library
- apply snapshot manifests with the client
- adjust README requirements

## Testing
- `python -m cluster_rollback.snapshot --help`
- `python -m py_compile cluster_rollback/snapshot.py cluster_rollback/web/app.py`


------
https://chatgpt.com/codex/tasks/task_b_687d30f4727c832ab4eadb06f1dc4013