### PR TITLE
Fix GitPython error by installing git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 FROM python:3.8-slim
 WORKDIR /app
+
+# GitPython requires the `git` executable. Install it in the image
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
+
 COPY . .
 CMD ["python", "-m", "cluster_rollback.web.app"]

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ It includes both a CLI utility and a web interface with a timeline of commits.
 * Python 3.8+
 * Access to your cluster via a kubeconfig file (no `kubectl` required)
 * Access to a local or remote Git repository
+* Git installed in the environment (required by GitPython). The provided
+  Dockerfile installs it automatically.
 
 Install dependencies:
 


### PR DESCRIPTION
## Summary
- install git in the Docker image so GitPython can run
- document that git is required

## Testing
- `python -m py_compile cluster_rollback/*.py cluster_rollback/web/*.py`

------
https://chatgpt.com/codex/tasks/task_b_687d32b1e0b8832a9e27da466d6f8ce4