### PR TITLE
feat: k8s-манифесты и Helm chart для деплоя cluster-rollback

### DIFF
--- a/cluster_rollback/snapshot.py
+++ b/cluster_rollback/snapshot.py
@@ -23,7 +23,7 @@ def take_snapshot():
     os.makedirs(path, exist_ok=True)
     outfile = os.path.join(path, 'resources.yaml')
 
-    config.load_kube_config()
+    config.load_incluster_config()
     api_client = client.ApiClient()
     core = client.CoreV1Api(api_client)
     apps = client.AppsV1Api(api_client)
@@ -61,7 +61,7 @@ def rollback(commit):
     repo.git.checkout(commit, '--', SNAPSHOT_DIR)
     snapshot_path = os.path.join(SNAPSHOT_DIR, timestamp, 'resources.yaml')
 
-    config.load_kube_config()
+    config.load_incluster_config()
     utils.create_from_yaml(client.ApiClient(), snapshot_path)
     print(f'Rolled back to commit {commit}')
 

--- a/helm/cluster-rollback/Chart.yaml
+++ b/helm/cluster-rollback/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v2
+name: cluster-rollback
+version: 0.1.0
+description: Helm chart для деплоя приложения Cluster Rollback с RBAC и сервис-аккаунтом 

--- a/helm/cluster-rollback/README.md
+++ b/helm/cluster-rollback/README.md
@@ -1,0 +1,30 @@
+# Cluster Rollback Helm Chart
+
+## Быстрый старт
+
+```sh
+helm install cluster-rollback ./helm/cluster-rollback --create-namespace --namespace cluster-rollback
+```
+
+## Параметры values.yaml
+- `namespace` — namespace для деплоя
+- `image.repository` — docker-образ
+- `image.tag` — тег образа
+- `service.type` — тип сервиса (ClusterIP/NodePort/LoadBalancer)
+- `service.port` — порт сервиса
+- `service.targetPort` — порт контейнера
+- `replicaCount` — количество реплик
+
+## Что разворачивается
+- Namespace
+- ServiceAccount
+- ClusterRole/ClusterRoleBinding
+- Deployment
+- Service
+
+## Пример доступа к UI
+
+```sh
+kubectl port-forward svc/cluster-rollback 8080:80 -n cluster-rollback
+# Открыть http://localhost:8080
+``` 

--- a/helm/cluster-rollback/templates/clusterrole.yaml
+++ b/helm/cluster-rollback/templates/clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-rollback-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"] 

--- a/helm/cluster-rollback/templates/clusterrolebinding.yaml
+++ b/helm/cluster-rollback/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-rollback-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-rollback-role
+subjects:
+  - kind: ServiceAccount
+    name: cluster-rollback-sa
+    namespace: {{ .Values.namespace }} 

--- a/helm/cluster-rollback/templates/deployment.yaml
+++ b/helm/cluster-rollback/templates/deployment.yaml
@@ -2,9 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cluster-rollback
-  namespace: cluster-rollback
+  namespace: {{ .Values.namespace }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
       app: cluster-rollback
@@ -16,18 +16,8 @@ spec:
       serviceAccountName: cluster-rollback-sa
       containers:
         - name: web
-          image: ghcr.io/harchuk/cluster-rollback:latest
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["python", "-m", "cluster_rollback.web.app"]
           ports:
-            - containerPort: 8000
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: cluster-rollback
-spec:
-  selector:
-    app: cluster-rollback
-  ports:
-  - port: 80
-    targetPort: 8000
+            - containerPort: 8000 

--- a/helm/cluster-rollback/templates/namespace.yaml
+++ b/helm/cluster-rollback/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }} 

--- a/helm/cluster-rollback/templates/service.yaml
+++ b/helm/cluster-rollback/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-rollback
+  namespace: {{ .Values.namespace }}
+spec:
+  selector:
+    app: cluster-rollback
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+  type: {{ .Values.service.type }} 

--- a/helm/cluster-rollback/templates/serviceaccount.yaml
+++ b/helm/cluster-rollback/templates/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-rollback-sa
+  namespace: {{ .Values.namespace }} 

--- a/helm/cluster-rollback/values.yaml
+++ b/helm/cluster-rollback/values.yaml
@@ -1,0 +1,10 @@
+namespace: cluster-rollback
+image:
+  repository: ghcr.io/harchuk/cluster-rollback
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 8000
+replicaCount: 1 

--- a/k8s/clusterrole.yaml
+++ b/k8s/clusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cluster-rollback-role
+rules:
+  - apiGroups: [""]
+    resources: ["pods", "services"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets", "statefulsets", "daemonsets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"] 

--- a/k8s/clusterrolebinding.yaml
+++ b/k8s/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cluster-rollback-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-rollback-role
+subjects:
+  - kind: ServiceAccount
+    name: cluster-rollback-sa
+    namespace: cluster-rollback 

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-rollback 

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-rollback
+  namespace: cluster-rollback
+spec:
+  selector:
+    app: cluster-rollback
+  ports:
+    - port: 80
+      targetPort: 8000 

--- a/k8s/serviceaccount.yaml
+++ b/k8s/serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cluster-rollback-sa
+  namespace: cluster-rollback 


### PR DESCRIPTION
- Добавлены манифесты для деплоя в Kubernetes: Namespace, ServiceAccount, ClusterRole, ClusterRoleBinding, Deployment, Service.\n- Добавлен Helm chart с шаблонами для всех ресурсов и README по установке.\n- Все ресурсы деплоятся в namespace cluster-rollback с отдельным сервис-аккаунтом и нужными правами.\n- Удобно для ручного деплоя и для Helm-установки.