### PR TITLE
Логирование количества объектов для каждого ресурса в снапшоте

### DIFF
--- a/cluster_rollback/snapshot.py
+++ b/cluster_rollback/snapshot.py
@@ -29,7 +29,9 @@ def collect_resources(api_client):
 
     def safe_list(fn, name):
         try:
-            return fn()
+            items = fn()
+            print(f"[SNAPSHOT] {name}: {len(items)} объектов")
+            return items
         except Exception as e:
             print(f"[ERROR] Не удалось получить {name}: {e}")
             return []


### PR DESCRIPTION
- Для каждого типа ресурса теперь в логах выводится количество собранных объектов при создании снапшота.\n- Это поможет быстро диагностировать, что реально попадает в backup и почему снапшот может быть пустым.